### PR TITLE
 Add playbooks for replication system, change playbooks for file access 

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -33,6 +33,6 @@ iscsiPortal_netmask: 255.255.255.0
 
 fileInterface_ipPort: spa_eth0
 
-fileInterface_ipAddress: 192.168.70.222
+fileInterface_ipAddress: 192.168.70.223
 
 replicationInterface_ip: 192.168.70.228

--- a/playbooks/complex/demo_file_access.yml
+++ b/playbooks/complex/demo_file_access.yml
@@ -58,8 +58,8 @@
           username: "{{ username }}"
           password: "{{ password }}"
         create:
-          nasServer: {id: "{{ create_nas_server_results['output']['create']['id'] }}"}
-          ipPort: {id: "spa_eth0"}
+          nasServer: {'id': "{{ create_nas_server_results['output']['create']['id'] }}"}
+          ipPort: {'id': "spa_eth0"}
           ipAddress: "{{ fileInterface_ip }}"
       register: file_interface_create_results
     - debug: var=file_interface_create_results['output']

--- a/playbooks/complex/demo_replication.yml
+++ b/playbooks/complex/demo_replication.yml
@@ -1,0 +1,205 @@
+---
+- hosts: localhost
+  tasks:
+    #pool and nasServer on 217
+    - name: get disks
+      virtualDisk:
+       login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+       get:
+         fields: id
+      register: get_disks_results
+    - debug: var=get_disks_results['output']['get']
+
+    - name: Create pool
+      pool:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        createVSA:
+          name: pool217
+          addPoolUnitParameters: ["poolUnit": "{{ get_disks_results['output']['get'][0] }}", "poolUnit": "{{ get_disks_results['output']['get'][1] }}"]
+      register: create_pool_results
+    - debug: var=create_pool_results['output']
+
+    - name: create Nas Server
+      nasServer:
+         login:
+           unityIP: "{{ host }}"
+           username: "{{ username }}"
+           password: "{{ password }}"
+         create:
+           name: nasServer217
+           homeSP: {id: 'spa'}
+           pool:  {id: "{{ create_pool_results['output']['createVSA']['id'] }}"}
+           isMultiProtocolEnabled: false
+      register: create_nas_server_results
+    - debug: var=create_nas_server_results['output']
+
+    - name: create fileInterface
+      fileInterface:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        create:
+          nasServer: {id: "{{ create_nas_server_results['output']['create']['id'] }}"}
+          ipPort: {id: "spa_eth0"}
+          ipAddress: "{{ fileInterface_ip }}"
+      register: file_interface_create_results
+    - debug: var=file_interface_create_results['output']
+
+    - name: create file system
+      filesystem:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        create:
+          name: file_system217
+          fsParameters:
+            pool:  {id: "{{ create_pool_results['output']['createVSA']['id'] }}"}
+            nasServer: {id: "{{ create_nas_server_results['output']['create']['id'] }}"}
+            size: 5368709120 # size 5 GB
+            supportedProtocols: 0
+      register: file_system_create_results217
+    - debug: var=file_system_create_results217['output']
+
+    - name: create nfsShare
+      nfsShare:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        create:
+          storageResource: {'id': "{{ file_system_create_results217['output']['create']['storageResource']['id'] }}"}
+          name: nfsShare217
+          path: '/'
+      register: create_nfs_share_results
+    - debug: var=create_nfs_share_results['output']
+
+  #pool and nasServer on 218
+    - name: get disks
+      virtualDisk:
+       login:
+          unityIP: "{{ host2 }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+       get:
+         fields: id
+      register: get_disks_results
+    - debug: var=get_disks_results['output']['get']
+
+    - name: Create pool
+      pool:
+        login:
+          unityIP: "{{ host2 }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        createVSA:
+          name: pool218
+          addPoolUnitParameters: ["poolUnit": "{{ get_disks_results['output']['get'][0] }}", "poolUnit": "{{ get_disks_results['output']['get'][1] }}"]
+      register: create_pool_results
+    - debug: var=create_pool_results['output']
+
+    - name: create Nas Server
+      nasServer:
+         login:
+           unityIP: "{{ host2 }}"
+           username: "{{ username }}"
+           password: "{{ password }}"
+         create:
+           name: nasServer218
+           homeSP: {id: 'spa'}
+           pool:  {id: "{{ create_pool_results['output']['createVSA']['id'] }}"}
+           isMultiProtocolEnabled: false
+           isReplicationDestination: true
+      register: create_nas_server_results
+    - debug: var=create_nas_server_results['output']
+
+    - name: create file system
+      filesystem:
+        login:
+          unityIP: "{{ host2 }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        create:
+          name: file_system218
+          fsParameters:
+            pool:  {id: "{{ create_pool_results['output']['createVSA']['id'] }}"}
+            nasServer: {id: "{{ create_nas_server_results['output']['create']['id'] }}"}
+            size: 1368709120 # size 1 GB
+            supportedProtocols: 0
+            isReplicationDestination: true
+      register: file_system_create_results218
+    - debug: var=file_system_create_results218['output']
+    #creating replication 
+
+    - name: get filesystem's storageResource id on 217
+      commonGetPost:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        get:
+          resource_type: filesystem
+          id: "{{ file_system_create_results217['output']['create']['id'] }}" 
+          fields: storageResource
+      register: get_storageId217
+    - debug: var=get_storageId217['output']
+
+    - name: get filesystem's storageResource id on 218
+      commonGetPost:
+        login:
+          unityIP: "{{ host2 }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        get:
+          resource_type: filesystem
+          id: "{{ file_system_create_results218['output']['create']['id'] }}" 
+          fields: storageResource
+      register: get_storageId218
+    - debug: var=get_storageId218['output']
+
+    - name: create remoteSystem
+      remoteSystem:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        create:
+          managementAddress: "{{ host2 }}"
+          remoteUsername: "{{ username }}"
+          remotePassword: "{{ password }}"
+      register: get_storageId218
+    - debug: var=get_storageId218['output']
+
+    - name: create replicationInterface
+      replicationInterface:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        create:
+          sp: {id: 'spa'}
+          ipPort: {id: "spa_eth0"}
+          ipAddress: "{{ replicationInterface_ip }}"
+      register: get_storageId218
+    - debug: var=get_storageId218['output']
+
+    - name: create replicationSession
+      replicationSession:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        create:
+          srcResourceId: "{{ get_storageId217['output']['get'][0]['storageResource']['id'] }}"
+          dstResourceId: "{{ get_storageId218['output']['get'][0]['storageResource']['id'] }}"
+          maxTimeOutOfSync: 5
+          #max time(minutes) to wait before sync
+      register: file_system_create_results
+    - debug: var=file_system_create_results['output']

--- a/playbooks/complex/replication.yml
+++ b/playbooks/complex/replication.yml
@@ -1,0 +1,71 @@
+---
+- hosts: localhost
+  vars_files:
+    - ../../group_vars/all
+  tasks:
+    - name: get filesystem's storageResource id on 217
+      commonGetPost:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        get:
+          resource_type: filesystem
+          #id: "{{ file_system_create_results217['output']['create']['id'] }}" 
+          fields: storageResource
+      register: get_storageId217
+    - debug: var=get_storageId217['output']
+
+    - name: get filesystem's storageResource id on 218
+      commonGetPost:
+        login:
+          unityIP: "{{ host2 }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        get:
+          resource_type: filesystem
+          #id: "{{ file_system_create_results218['output']['create']['id'] }}" 
+          fields: storageResource
+      register: get_storageId218
+    - debug: var=get_storageId218['output']
+
+    - name: create remoteSystem
+      remoteSystem:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        create:
+          managementAddress: "{{ host2 }}"
+          #remoteUsername: "{{ username }}"
+          #remotePassword: "{{ password }}"
+      register: get_storageId218
+    - debug: var=get_storageId218['output']
+
+
+    - name: create replicationInterface
+      replicationInterface:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        create:
+          sp: {id: 'spa'}
+          ipPort: {id: "spa_eth0"}
+          ipAddress: "{{ replicationInterface_ip }}"
+      register: get_storageId218
+    - debug: var=get_storageId218['output']
+
+    - name: create replicationSession
+      replicationSession:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        create:
+          srcResourceId: "{{ get_storageId217['output']['get'][0]['storageResource']['id'] }}"
+          dstResourceId: "{{ get_storageId218['output']['get'][0]['storageResource']['id'] }}"
+          maxTimeOutOfSync: 3
+          #max time to wait before sync
+      register: file_system_create_results
+    - debug: var=file_system_create_results['output']

--- a/playbooks/simple/fileInterface_create.yml
+++ b/playbooks/simple/fileInterface_create.yml
@@ -3,6 +3,18 @@
   vars_files:
     - ../../group_vars/all
   tasks:
+    - name: get nasServer id
+      commonGetPost:
+        login:
+          unityIP: "{{ unity_host }}"
+          username: "{{ unity_username }}"
+          password: "{{ unity_password }}"
+        get:
+          resource_type: nasServer
+          fields: id
+      register: result1
+    - debug: var=result1['output']
+
     - name: Create fileInterface
       fileInterface:
         login:
@@ -10,8 +22,8 @@
           username: "{{ unity_username }}"
           password: "{{ unity_password }}"
         create:
-          nasServer: {id: "{{ nasServer_id }}"}
+          nasServer: {id: "{{ result1['output']['get'][0]['id'] }}"}
           ipPort: {id: "{{ fileInterface_ipPort }}"}
           ipAddress: "{{ fileInterface_ipAddress }}"
-      register: result1
-    - debug: var=result1['output']
+      register: result2
+    - debug: var=result2['output']

--- a/playbooks/simple/fileInterface_delete.yml
+++ b/playbooks/simple/fileInterface_delete.yml
@@ -4,6 +4,16 @@
     - ../../group_vars/all
   tasks:
     - name: Get fileInterface_id
+      commonGetPost:
+        login:
+          unityIP: "{{ unity_host }}"
+          username: "{{ unity_username }}"
+          password: "{{ unity_password }}"
+        get:
+          resource_type: fileInterface
+          fields: id  
+      register: result1
+    - debug: var=result1['output']
 
     - name: Delete fileInterface
       fileInterface:
@@ -12,6 +22,6 @@
           username: "{{ unity_username }}"
           password: "{{ unity_password }}"
         delete:
-          id: "{{ fileInterface_id }}"
+          id: "{{ result1['output']['get'][0]['id'] }}"
       register: result1
     - debug: var=result1['output']

--- a/playbooks/simple/filesystem_create.yml
+++ b/playbooks/simple/filesystem_create.yml
@@ -39,7 +39,8 @@
           fsParameters:
             pool:  {'id': "{{ result1['output']['get'][0]['id'] }}"}
             nasServer: {'id': "{{ result2['output']['get'][0]['id'] }}"}
-            size: 3368709120 # size 1 GB
+            size: 3368709120 # size 3 GB
             supportedProtocols: 0
+          #replicationParameters: {'isReplicationDestination': true}
       register: file_system_create_results
     - debug: var=file_system_create_results['output']

--- a/playbooks/simple/get.yml
+++ b/playbooks/simple/get.yml
@@ -1,0 +1,16 @@
+---
+- hosts: localhost
+  vars_files:
+    - ../../group_vars/all
+  tasks:
+    - name: get
+      commonGetPost:
+        login:
+          unityIP: "{{ unity_host }}"
+          username: "{{ unity_username }}"
+          password: "{{ unity_password }}"
+        get:
+          resource_type: ipPort
+          fields: id
+      register: result1
+    - debug: var=result1['output']

--- a/playbooks/simple/nasServer_create.yml
+++ b/playbooks/simple/nasServer_create.yml
@@ -3,6 +3,18 @@
   vars_files:
     - ../../group_vars/all
   tasks:
+    - name: get pool id
+      commonGetPost:
+        login:
+          unityIP: "{{ unity_host }}"
+          username: "{{ unity_username }}"
+          password: "{{ unity_password }}"
+        get:
+          resource_type: pool
+          fields: id
+      register: get_pool
+    - debug: var=get_pool['output']
+
     - name: Create nasServer
       nasServer:
         login:
@@ -11,8 +23,8 @@
           password: "{{ unity_password }}"
         create:
           name: "{{ nasServer_name }}"
-          homeSP: {id: "{{ homeSP_id }}"}
-          pool: {id: "{{ pool_id }}"}
+          homeSP: {id: "spa"}
+          pool: {id: "{{ get_pool['output']['get'][0]['id'] }}"}
       register: result1
     - debug: var=result1['output']
 

--- a/playbooks/simple/nfsShare_create.yml
+++ b/playbooks/simple/nfsShare_create.yml
@@ -18,9 +18,9 @@
     - name: Create nfsShare
       nfsShare:
         login:
-          unityIP: 192.168.70.217
-          username: admin
-          password: Password123!
+          unityIP: "{{ unity_host }}"
+          username: "{{ unity_username }}"
+          password: "{{ unity_password }}"
         create:
           storageResource: {'id': "{{ result['output']['get'][0]['storageResource']['id'] }}"}
           name: nfsShareTestPlaybook

--- a/playbooks/simple/remoteSystem_create.yml
+++ b/playbooks/simple/remoteSystem_create.yml
@@ -1,0 +1,20 @@
+---
+- hosts: localhost
+  vars_files:
+    - ../../group_vars/all
+  tasks:
+    - name: create remoteSystem
+      remoteSystem:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        create:
+          #all of the further parameters are required. DellEMC documentation lies:)
+          managementAddress: "{{ host2 }}"
+          remoteUsername: "{{ username }}"
+          remotePassword: "{{ password }}"
+          localUsername: "{{ username }}"
+          localPassword: "{{ password }}"
+      register: create_remoteSystem
+    - debug: var=create_remoteSystem['output']

--- a/playbooks/simple/remoteSystem_delete.yml
+++ b/playbooks/simple/remoteSystem_delete.yml
@@ -1,0 +1,27 @@
+---
+- hosts: localhost
+  vars_files:
+    - ../../group_vars/all
+  tasks:
+    - name: get remotesystem id
+      commonGetPost:
+        login:
+          unityIP: "{{ unity_host }}"
+          username: "{{ unity_username }}"
+          password: "{{ unity_password }}"
+        get:
+          resource_type: remoteSystem
+          fields: id
+      register: result1
+    - debug: var=result1['output']
+
+    - name: delete remoteSystem
+      remoteSystem:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        delete:
+          id: "{{ result1['output']['get'][1]['id'] }}"
+      register: delete_remoteSystem
+    - debug: var=delete_remoteSystem['output']

--- a/playbooks/simple/replicationInterface_create.yml
+++ b/playbooks/simple/replicationInterface_create.yml
@@ -1,0 +1,17 @@
+---
+- hosts: localhost
+  vars_files:
+    - ../../group_vars/all
+  tasks:
+    - name: create replicationInterface
+      replicationInterface:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        create:
+          sp: {'id': 'spa'}
+          ipPort: {'id': 'spa_eth0'}
+          ipAddress: "{{ replicationInterface_ip }}"
+      register: get_storageId218
+    - debug: var=get_storageId218['output']

--- a/playbooks/simple/replicationInterface_delete.yml
+++ b/playbooks/simple/replicationInterface_delete.yml
@@ -1,0 +1,28 @@
+---
+- hosts: localhost
+  vars_files:
+    - ../../group_vars/all
+  tasks:
+    - name: get replicationInterface id
+      commonGetPost:
+        login:
+          unityIP: "{{ unity_host }}"
+          username: "{{ unity_username }}"
+          password: "{{ unity_password }}"
+        get:
+          resource_type: replicationInterface
+          fields: id
+      register: result1
+    - debug: var=result1['output']
+
+
+    - name: delete replicationInterface
+      replicationInterface:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        delete:
+          id: result1['output']['get'][0]['id']
+      register: delete_repl
+    - debug: var=delete_repl['output']

--- a/playbooks/simple/replicationSession_create.yml
+++ b/playbooks/simple/replicationSession_create.yml
@@ -1,0 +1,83 @@
+---
+- hosts: localhost
+  vars_files:
+    - ../../group_vars/all
+  tasks:
+    - name: Get nasServer id
+      commonGetPost:
+        login:
+          unityIP: "{{ unity_host }}"
+          username: "{{ unity_username }}"
+          password: "{{ unity_password }}"
+        get:
+          resource_type: nasServer
+          fields: id
+      register: r1
+    - debug: var=r1['output']['get'][0]['id']
+
+    - name: Get nasServer id
+      commonGetPost:
+        login:
+          unityIP: "{{ unity_host2 }}"
+          username: "{{ unity_username }}"
+          password: "{{ unity_password }}"
+        get:
+          resource_type: nasServer
+          fields: id
+      register: r2
+    - debug: var=r2['output']['get'][0]['id']
+
+    - name: get filesystem's storageResource id on 217
+      commonGetPost:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        get:
+          resource_type: filesystem
+          #id: "{{ file_system_create_results217['output']['create']['id'] }}" 
+          fields: storageResource
+      register: get_storageId217
+    - debug: var=get_storageId217['output']
+
+    - name: get filesystem's storageResource id on 218
+      commonGetPost:
+        login:
+          unityIP: "{{ host2 }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        get:
+          resource_type: filesystem
+          #id: "{{ file_system_create_results218['output']['create']['id'] }}" 
+          fields: storageResource
+      register: get_storageId218
+    - debug: var=get_storageId218['output']
+
+    - name: Get remoteSystem id
+      commonGetPost:
+        login:
+          unityIP: "{{ unity_host }}"
+          username: "{{ unity_username }}"
+          password: "{{ unity_password }}"
+        get:
+          resource_type: remoteSystem
+          fields: id
+      register: rs
+    - debug: var=rs['output']['get'][0]['id']
+
+    - name: create replicationSession
+      replicationSession:
+        login:
+          unityIP: "{{ host }}"
+          username: "{{ username }}"
+          password: "{{ password }}"
+        create:
+          remoteSystem: {'id': "{{ rs['output']['get'][1]['id'] }}"}
+          srcResourceId: "{{ r1['output']['get'][0]['id'] }}"
+          #"{{ get_storageId217['output']['get'][0]['storageResource']['id'] }}"
+          dstResourceId: "{{ r2['output']['get'][0]['id'] }}"
+          #"{{ get_storageId218['output']['get'][0]['storageResource']['id'] }}"
+          maxTimeOutOfSync: 10
+          #max time to wait before sync
+      register: file_system_create_results
+    - debug: var=file_system_create_results['output']


### PR DESCRIPTION
Add getters to fileInterface playbooks, add fileInterface_ip to group_vars
Add playbooks to create and delete remoteSystem, replicationInterface.
Add a playbook to create replicationSession.
Change playbooks to create nasServer, filesystem and nfsShare
(add "get id" requests).
Add complex playbooks to create replication when you've already got
an nfsShare and when you have a clean system.